### PR TITLE
feat(test-ci): add pull-request workflows

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,27 @@
+name: "Pull Request"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+env:
+  GO_VERSION: 1.23
+jobs:
+  lint-test:
+    name: "Lint and Test"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "Setup Go"
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: "Golang CI Lint"
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60
+      - name: "Run Tests"
+        run: go test -v ./...


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate linting and testing for pull requests. The workflow is configured to trigger on pull request events and includes steps to set up the Go environment, run linting, and execute tests.

Key changes:

* Added a new GitHub Actions workflow configuration file `.github/workflows/pull-request.yaml` to automate linting and testing for pull requests.
* Configured the workflow to trigger on pull request events: `opened`, `synchronize`, and `reopened`.
* Set up the Go environment using `actions/setup-go@v5` with Go version 1.23.
* Included steps to run `golangci-lint` using `golangci/golangci-lint-action@v6` and execute tests with `go test -v ./...`.